### PR TITLE
A few fixes

### DIFF
--- a/src/main/java/org/leleuj/RatpackPac4jDemo.java
+++ b/src/main/java/org/leleuj/RatpackPac4jDemo.java
@@ -22,11 +22,13 @@ public class RatpackPac4jDemo {
          RatpackServer.start(server -> server
                          .serverConfig(ServerConfig.baseDir(new File("src/main")).publicAddress(new URI(URL)).port(PORT).build())
                          .registry(Guice.registry(b -> {
-                             b.add(new SessionModule());
-                             b.add(new MapSessionsModule(10, 5));
+                             b.bind(ServerErrorHandler.class, AppServerErrorHandler.class);
+                             b.bind(ClientErrorHandler.class, AppClientErrorHandler.class);
                              b.add(TextTemplateModule.class);
+                             b.add(new MapSessionsModule(10, 5));
+                             b.add(new SessionModule());
                          }))
-                        .handlers(chain -> new AppHandlerFactory())
+                         .handlers(new AppHandlerFactory())
         );
 
     }


### PR DESCRIPTION
* Adjust ordering of guice modules
* get handler chain working
* fix registration of error handlers.

This isn't functional yet.  To diagnose the problems, I recommend commenting out the two lines in RatpackPac4jDemo to register the error handlers, and adding a ".development(true)" to the server config builder block to enable the default development error pages.  When I do that, I get a `org.pac4j.core.exception.TechnicalException: profileCreator cannot be null` when attempting to access index.html, which I think is due to an improperly configured `FormClient`.